### PR TITLE
chore: gitignore private files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,8 @@ dist/
 build/
 output/*.mp4
 output/*.mkv
+output/*.youtube.md
 temp/
 logs/
+scenarios/
+SESSION.md


### PR DESCRIPTION
## Summary
- Gitignore `scenarios/` (private scenario files, not part of open source)
- Gitignore `SESSION.md` (session tracking)
- Gitignore `output/*.youtube.md` (upload metadata)

These files are used locally but should never be pushed to the public repo.