### PR TITLE
feat: cross-platform screen capture and audio playback (v1.2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,14 +45,20 @@ VIDEO_HEIGHT=1080
 VIDEO_FPS=30
 
 # -----------------------------------------------------------------------------
-# Screen capture — macOS multi-monitor setup
+# Screen capture — multi-monitor / multi-platform setup
 # -----------------------------------------------------------------------------
 # Required only if you have multiple monitors and want to record a specific one.
-# Single monitor: leave defaults (0 and 0).
+# Single monitor: leave defaults.
 
-# ffmpeg avfoundation screen index
+# macOS: ffmpeg avfoundation screen index
 # Find yours: ffmpeg -f avfoundation -list_devices true -i ""
 CAPTURE_SCREEN=0
+
+# Linux/Windows: display identifier for ffmpeg
+# Linux (x11grab): X11 display, e.g. ":0.0" or ":0.0+100,200" (with offset)
+# Windows (gdigrab): "desktop" (full screen) or "title=Window Name" (specific window)
+# macOS: not used (CAPTURE_SCREEN is used instead)
+# CAPTURE_DISPLAY=:0.0
 
 # X pixel offset to position the browser window on the target screen via CDP
 # Each 2560px-wide screen adds 2560 to the offset

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # NeuraScreen
 
-![Version](https://img.shields.io/badge/version-1.1.0-blue)
+![Version](https://img.shields.io/badge/version-1.2.0-blue)
 ![PyPI](https://img.shields.io/badge/pip_install-neurascreen-3775A9?logo=pypi&logoColor=white)
 ![Python](https://img.shields.io/badge/python-3.12+-3776AB?logo=python&logoColor=white)
 ![Playwright](https://img.shields.io/badge/playwright-1.52-2EAD33?logo=playwright&logoColor=white)
 ![ffmpeg](https://img.shields.io/badge/ffmpeg-required-007808?logo=ffmpeg&logoColor=white)
-![Platform](https://img.shields.io/badge/platform-macOS-lightgrey?logo=apple&logoColor=white)
+![Platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey)
 ![License](https://img.shields.io/badge/license-MIT-green)
 
 **Automated demo video generator for web applications.**
@@ -339,11 +339,12 @@ All settings are in `.env`. See [`.env.example`](.env.example) for the full docu
 | `VIDEO_FPS` | `30` | Frames per second |
 | `BROWSER_HEADLESS` | `false` | Headless mode |
 
-### Screen capture (multi-monitor)
+### Screen capture (multi-monitor / multi-platform)
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `CAPTURE_SCREEN` | `0` | ffmpeg screen index |
+| `CAPTURE_SCREEN` | `0` | ffmpeg screen index (macOS avfoundation) |
+| `CAPTURE_DISPLAY` | `""` | Display identifier — Linux: X11 display (e.g. `:0.0`), Windows: `desktop` or `title=Window Name` |
 | `BROWSER_SCREEN_OFFSET` | `0` | Browser X pixel offset |
 
 ---
@@ -398,6 +399,7 @@ neurascreen/
 │   ├── config.py         # Configuration loader
 │   ├── scenario.py       # JSON parser & validator
 │   ├── browser.py        # Playwright browser engine
+│   ├── platform.py       # OS detection & platform-specific commands
 │   ├── recorder.py       # Screen capture (ffmpeg)
 │   ├── narrator.py       # TTS & timing sync
 │   ├── tts.py            # TTS abstraction (5 providers)
@@ -418,8 +420,8 @@ neurascreen/
 | Feature | macOS | Linux | Windows |
 |---------|-------|-------|---------|
 | Browser automation | Yes | Yes | Yes |
-| Screen capture | Yes (avfoundation) | Planned (x11grab) | Planned (gdigrab) |
-| Audio playback | Yes (afplay) | Planned (aplay) | Planned (powershell) |
+| Screen capture | Yes (avfoundation) | Yes (x11grab) | Yes (gdigrab) |
+| Audio playback | Yes (afplay) | Yes (paplay/aplay) | Yes (PowerShell) |
 | TTS | Yes | Yes | Yes |
 | Video assembly | Yes | Yes | Yes |
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,15 +17,15 @@
 - [x] pyproject.toml for `pip install neurascreen`
 - [x] `neurascreen` CLI entry point (instead of `python -m src`)
 - [x] `--version` flag
-- [ ] Configurable login form selectors (#3)
-- [ ] Configurable canvas/modal selectors for drag/delete_node/close_modal (#4)
-- [ ] Unit tests for assembler and utils (#5)
+- [x] Configurable login form selectors (#3)
+- [x] Configurable canvas/modal selectors for drag/delete_node/close_modal (#4)
+- [x] Unit tests for assembler and utils (#5)
 
 ## v1.2 — Cross-platform
 
-- [ ] Linux screen capture via x11grab (#1)
-- [ ] Linux audio playback via aplay/paplay (#2)
-- [ ] Windows screen capture via gdigrab (#8)
+- [x] Linux screen capture via x11grab (#1)
+- [x] Linux audio playback via aplay/paplay (#2)
+- [x] Windows screen capture via gdigrab (#8)
 
 ## v1.3 — Production features
 

--- a/neurascreen/__init__.py
+++ b/neurascreen/__init__.py
@@ -1,3 +1,3 @@
 """NeuraScreen — Automated screen walkthrough video generator."""
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"

--- a/neurascreen/assembler.py
+++ b/neurascreen/assembler.py
@@ -40,7 +40,12 @@ class Assembler:
     @staticmethod
     def _check_ffmpeg() -> None:
         if not shutil.which("ffmpeg"):
-            raise RuntimeError("ffmpeg not found. Install it: brew install ffmpeg")
+            raise RuntimeError(
+                "ffmpeg not found. Install it: "
+                "brew install ffmpeg (macOS) / "
+                "sudo apt install ffmpeg (Linux) / "
+                "choco install ffmpeg (Windows)"
+            )
 
     def convert_to_mp4(
         self,

--- a/neurascreen/browser.py
+++ b/neurascreen/browser.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from playwright.sync_api import Page, BrowserContext, sync_playwright, Playwright
 
 from .config import Config
+from .platform import get_audio_play_command
 from .scenario import Scenario, Step
 
 logger = logging.getLogger("videogen")
@@ -171,11 +172,12 @@ class BrowserEngine:
 
     @staticmethod
     def _play_audio(audio_path: Path) -> subprocess.Popen | None:
-        """Play a WAV file in background via afplay (macOS)."""
+        """Play a WAV file in background using the platform-native player."""
         if not audio_path or not audio_path.exists():
             return None
+        cmd = get_audio_play_command(str(audio_path))
         return subprocess.Popen(
-            ["afplay", str(audio_path)],
+            cmd,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )

--- a/neurascreen/config.py
+++ b/neurascreen/config.py
@@ -29,8 +29,9 @@ class Config:
     video_height: int
     video_fps: int
 
-    # Screen capture (macOS)
+    # Screen capture
     capture_screen: int
+    capture_display: str
     browser_screen_offset: int
 
     # TTS
@@ -80,6 +81,7 @@ class Config:
             video_fps=int(os.getenv("VIDEO_FPS", "30")),
             # Screen capture
             capture_screen=int(os.getenv("CAPTURE_SCREEN", "0")),
+            capture_display=os.getenv("CAPTURE_DISPLAY", ""),
             browser_screen_offset=int(os.getenv("BROWSER_SCREEN_OFFSET", "0")),
             # TTS
             tts_provider=os.getenv("TTS_PROVIDER", "gradium"),

--- a/neurascreen/platform.py
+++ b/neurascreen/platform.py
@@ -1,0 +1,172 @@
+"""Platform detection and OS-specific command builders for screen capture and audio playback."""
+
+import shutil
+import sys
+
+PLATFORM_MACOS = "darwin"
+PLATFORM_LINUX = "linux"
+PLATFORM_WINDOWS = "win32"
+
+
+def get_platform() -> str:
+    """Return the current platform identifier."""
+    return sys.platform
+
+
+def is_macos() -> bool:
+    return sys.platform == PLATFORM_MACOS
+
+
+def is_linux() -> bool:
+    return sys.platform.startswith(PLATFORM_LINUX)
+
+
+def is_windows() -> bool:
+    return sys.platform == PLATFORM_WINDOWS
+
+
+def get_capture_command(
+    output_path: str,
+    fps: int,
+    capture_screen: int | str,
+    capture_display: str = "",
+) -> list[str]:
+    """Build the ffmpeg screen capture command for the current platform.
+
+    Args:
+        output_path: Path for the output MKV file.
+        fps: Frames per second.
+        capture_screen: Screen index (macOS avfoundation) or ignored on other platforms.
+        capture_display: Display identifier — X11 display for Linux (e.g. ":0.0+0,0"),
+                         or window title for Windows (e.g. "desktop"). Falls back to
+                         sensible defaults per platform if empty.
+
+    Returns:
+        Complete ffmpeg command as a list of strings.
+    """
+    base = ["ffmpeg", "-y"]
+    encode = [
+        "-c:v", "libx264",
+        "-preset", "ultrafast",
+        "-crf", "15",
+        "-pix_fmt", "yuv420p",
+        "-r", str(fps),
+        "-f", "matroska",
+        output_path,
+    ]
+
+    if is_macos():
+        return base + [
+            "-f", "avfoundation",
+            "-framerate", str(fps),
+            "-capture_cursor", "1",
+            "-i", f"{capture_screen}:none",
+        ] + encode
+
+    if is_linux():
+        display = capture_display or ":0.0"
+        return base + [
+            "-f", "x11grab",
+            "-framerate", str(fps),
+            "-draw_mouse", "1",
+            "-i", display,
+        ] + encode
+
+    if is_windows():
+        input_name = capture_display or "desktop"
+        return base + [
+            "-f", "gdigrab",
+            "-framerate", str(fps),
+            "-draw_mouse", "1",
+            "-i", input_name,
+        ] + encode
+
+    raise RuntimeError(f"Unsupported platform for screen capture: {sys.platform}")
+
+
+def get_audio_play_command(audio_path: str) -> list[str]:
+    """Return the command to play a WAV file on the current platform.
+
+    Args:
+        audio_path: Path to the WAV file.
+
+    Returns:
+        Command as a list of strings.
+    """
+    if is_macos():
+        return ["afplay", str(audio_path)]
+
+    if is_linux():
+        # Prefer paplay (PulseAudio) if available, fallback to aplay (ALSA)
+        if shutil.which("paplay"):
+            return ["paplay", str(audio_path)]
+        if shutil.which("aplay"):
+            return ["aplay", "-q", str(audio_path)]
+        raise RuntimeError(
+            "No audio player found. Install pulseaudio (paplay) or alsa-utils (aplay)."
+        )
+
+    if is_windows():
+        # PowerShell can play WAV files natively via SoundPlayer
+        return [
+            "powershell", "-NoProfile", "-Command",
+            f"(New-Object System.Media.SoundPlayer '{audio_path}').PlaySync()",
+        ]
+
+    raise RuntimeError(f"Unsupported platform for audio playback: {sys.platform}")
+
+
+def get_platform_name() -> str:
+    """Return a human-readable platform name."""
+    if is_macos():
+        return "macOS"
+    if is_linux():
+        return "Linux"
+    if is_windows():
+        return "Windows"
+    return f"Unknown ({sys.platform})"
+
+
+def check_capture_dependencies() -> list[str]:
+    """Check that platform-specific capture dependencies are available.
+
+    Returns:
+        List of error messages (empty if all OK).
+    """
+    errors = []
+
+    if not shutil.which("ffmpeg"):
+        errors.append("ffmpeg not found. Install it for screen capture.")
+
+    if is_linux():
+        # x11grab requires an X11 display
+        import os
+        if not os.environ.get("DISPLAY"):
+            errors.append("DISPLAY environment variable not set. x11grab requires X11.")
+
+    return errors
+
+
+def check_audio_dependencies() -> list[str]:
+    """Check that platform-specific audio playback dependencies are available.
+
+    Returns:
+        List of error messages (empty if all OK).
+    """
+    errors = []
+
+    if is_macos():
+        if not shutil.which("afplay"):
+            errors.append("afplay not found (should be built-in on macOS).")
+
+    elif is_linux():
+        if not shutil.which("paplay") and not shutil.which("aplay"):
+            errors.append(
+                "No audio player found. Install pulseaudio (paplay) or alsa-utils (aplay)."
+            )
+
+    elif is_windows():
+        if not shutil.which("powershell"):
+            errors.append("PowerShell not found (required for audio playback on Windows).")
+
+    return errors

--- a/neurascreen/recorder.py
+++ b/neurascreen/recorder.py
@@ -1,4 +1,4 @@
-"""Video recording orchestrator using macOS screen capture via ffmpeg avfoundation."""
+"""Video recording orchestrator using native screen capture via ffmpeg."""
 
 import logging
 import signal
@@ -9,6 +9,7 @@ from pathlib import Path
 from .config import Config
 from .scenario import Scenario
 from .browser import BrowserEngine
+from .platform import get_capture_command, get_platform_name
 
 logger = logging.getLogger("videogen")
 
@@ -24,25 +25,17 @@ class Recorder:
         self._ffmpeg_process: subprocess.Popen | None = None
 
     def _start_screen_capture(self, output_path: Path) -> None:
-        """Start ffmpeg avfoundation screen capture in background."""
+        """Start ffmpeg screen capture in background (platform-aware)."""
         output_path.parent.mkdir(parents=True, exist_ok=True)
 
-        cmd = [
-            "ffmpeg", "-y",
-            "-f", "avfoundation",
-            "-framerate", str(self.config.video_fps),
-            "-capture_cursor", "1",
-            "-i", f"{self.config.capture_screen}:none",
-            "-c:v", "libx264",
-            "-preset", "ultrafast",
-            "-crf", "15",
-            "-pix_fmt", "yuv420p",
-            "-r", str(self.config.video_fps),
-            "-f", "matroska",
-            str(output_path),
-        ]
+        cmd = get_capture_command(
+            output_path=str(output_path),
+            fps=self.config.video_fps,
+            capture_screen=self.config.capture_screen,
+            capture_display=self.config.capture_display,
+        )
 
-        logger.info(f"Starting screen capture (screen {self.config.capture_screen})...")
+        logger.info(f"Starting screen capture on {get_platform_name()} (screen {self.config.capture_screen})...")
         self._ffmpeg_process = subprocess.Popen(
             cmd,
             stdin=subprocess.PIPE,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "neurascreen"
-version = "1.1.0"
+version = "1.2.0"
 description = "Automated screen walkthrough video generator using Playwright, JSON scenarios and Text-to-Speech"
 readme = "README.md"
 license = "MIT"
@@ -22,6 +22,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Operating System :: MacOS",
     "Operating System :: POSIX :: Linux",
+    "Operating System :: Microsoft :: Windows",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Topic :: Multimedia :: Video",

--- a/tests/test_assembler.py
+++ b/tests/test_assembler.py
@@ -28,6 +28,7 @@ def _make_config(tmp_path: Path) -> Config:
         video_height=1080,
         video_fps=30,
         capture_screen=0,
+        capture_display="",
         browser_screen_offset=0,
         tts_provider="gradium",
         tts_api_key="",

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -1,0 +1,238 @@
+"""Tests for platform detection and OS-specific command builders."""
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from neurascreen.platform import (
+    PLATFORM_LINUX,
+    PLATFORM_MACOS,
+    PLATFORM_WINDOWS,
+    check_audio_dependencies,
+    check_capture_dependencies,
+    get_audio_play_command,
+    get_capture_command,
+    get_platform,
+    get_platform_name,
+    is_linux,
+    is_macos,
+    is_windows,
+)
+
+
+class TestPlatformDetection:
+    """Tests for platform detection functions."""
+
+    def test_get_platform_returns_string(self):
+        assert isinstance(get_platform(), str)
+
+    @patch("neurascreen.platform.sys")
+    def test_is_macos(self, mock_sys):
+        mock_sys.platform = "darwin"
+        assert is_macos()
+        assert not is_linux()
+        assert not is_windows()
+
+    @patch("neurascreen.platform.sys")
+    def test_is_linux(self, mock_sys):
+        mock_sys.platform = "linux"
+        assert is_linux()
+        assert not is_macos()
+        assert not is_windows()
+
+    @patch("neurascreen.platform.sys")
+    def test_is_windows(self, mock_sys):
+        mock_sys.platform = "win32"
+        assert is_windows()
+        assert not is_macos()
+        assert not is_linux()
+
+    @patch("neurascreen.platform.sys")
+    def test_platform_name_macos(self, mock_sys):
+        mock_sys.platform = "darwin"
+        assert get_platform_name() == "macOS"
+
+    @patch("neurascreen.platform.sys")
+    def test_platform_name_linux(self, mock_sys):
+        mock_sys.platform = "linux"
+        assert get_platform_name() == "Linux"
+
+    @patch("neurascreen.platform.sys")
+    def test_platform_name_windows(self, mock_sys):
+        mock_sys.platform = "win32"
+        assert get_platform_name() == "Windows"
+
+    @patch("neurascreen.platform.sys")
+    def test_platform_name_unknown(self, mock_sys):
+        mock_sys.platform = "freebsd"
+        assert "Unknown" in get_platform_name()
+
+
+class TestCaptureCommand:
+    """Tests for get_capture_command()."""
+
+    @patch("neurascreen.platform.sys")
+    def test_macos_avfoundation(self, mock_sys):
+        mock_sys.platform = "darwin"
+        cmd = get_capture_command("/tmp/out.mkv", 30, 1)
+        assert "avfoundation" in cmd
+        assert "-framerate" in cmd
+        assert "1:none" in cmd
+        assert cmd[0] == "ffmpeg"
+        assert cmd[-1] == "/tmp/out.mkv"
+
+    @patch("neurascreen.platform.sys")
+    def test_macos_capture_screen_index(self, mock_sys):
+        mock_sys.platform = "darwin"
+        cmd = get_capture_command("/tmp/out.mkv", 60, 2)
+        assert "2:none" in cmd
+        assert "60" in cmd
+
+    @patch("neurascreen.platform.sys")
+    def test_linux_x11grab(self, mock_sys):
+        mock_sys.platform = "linux"
+        cmd = get_capture_command("/tmp/out.mkv", 30, 0)
+        assert "x11grab" in cmd
+        assert ":0.0" in cmd
+        assert "-draw_mouse" in cmd
+
+    @patch("neurascreen.platform.sys")
+    def test_linux_custom_display(self, mock_sys):
+        mock_sys.platform = "linux"
+        cmd = get_capture_command("/tmp/out.mkv", 30, 0, capture_display=":1.0+100,200")
+        assert ":1.0+100,200" in cmd
+
+    @patch("neurascreen.platform.sys")
+    def test_linux_default_display(self, mock_sys):
+        mock_sys.platform = "linux"
+        cmd = get_capture_command("/tmp/out.mkv", 30, 0, capture_display="")
+        assert ":0.0" in cmd
+
+    @patch("neurascreen.platform.sys")
+    def test_windows_gdigrab(self, mock_sys):
+        mock_sys.platform = "win32"
+        cmd = get_capture_command("/tmp/out.mkv", 30, 0)
+        assert "gdigrab" in cmd
+        assert "desktop" in cmd
+        assert "-draw_mouse" in cmd
+
+    @patch("neurascreen.platform.sys")
+    def test_windows_custom_input(self, mock_sys):
+        mock_sys.platform = "win32"
+        cmd = get_capture_command("/tmp/out.mkv", 30, 0, capture_display="title=MyApp")
+        assert "title=MyApp" in cmd
+
+    @patch("neurascreen.platform.sys")
+    def test_unsupported_platform_raises(self, mock_sys):
+        mock_sys.platform = "freebsd"
+        with pytest.raises(RuntimeError, match="Unsupported platform"):
+            get_capture_command("/tmp/out.mkv", 30, 0)
+
+    @patch("neurascreen.platform.sys")
+    def test_common_encoding_params(self, mock_sys):
+        for platform in ["darwin", "linux", "win32"]:
+            mock_sys.platform = platform
+            cmd = get_capture_command("/tmp/out.mkv", 30, 0)
+            assert "-c:v" in cmd
+            assert "libx264" in cmd
+            assert "ultrafast" in cmd
+            assert "matroska" in cmd
+
+
+class TestAudioPlayCommand:
+    """Tests for get_audio_play_command()."""
+
+    @patch("neurascreen.platform.sys")
+    def test_macos_afplay(self, mock_sys):
+        mock_sys.platform = "darwin"
+        cmd = get_audio_play_command("/tmp/audio.wav")
+        assert cmd == ["afplay", "/tmp/audio.wav"]
+
+    @patch("neurascreen.platform.shutil")
+    @patch("neurascreen.platform.sys")
+    def test_linux_paplay_preferred(self, mock_sys, mock_shutil):
+        mock_sys.platform = "linux"
+        mock_shutil.which = lambda x: "/usr/bin/paplay" if x == "paplay" else None
+        cmd = get_audio_play_command("/tmp/audio.wav")
+        assert cmd[0] == "paplay"
+
+    @patch("neurascreen.platform.shutil")
+    @patch("neurascreen.platform.sys")
+    def test_linux_aplay_fallback(self, mock_sys, mock_shutil):
+        mock_sys.platform = "linux"
+        mock_shutil.which = lambda x: "/usr/bin/aplay" if x == "aplay" else None
+        cmd = get_audio_play_command("/tmp/audio.wav")
+        assert cmd[0] == "aplay"
+        assert "-q" in cmd
+
+    @patch("neurascreen.platform.shutil")
+    @patch("neurascreen.platform.sys")
+    def test_linux_no_player_raises(self, mock_sys, mock_shutil):
+        mock_sys.platform = "linux"
+        mock_shutil.which = lambda x: None
+        with pytest.raises(RuntimeError, match="No audio player found"):
+            get_audio_play_command("/tmp/audio.wav")
+
+    @patch("neurascreen.platform.sys")
+    def test_windows_powershell(self, mock_sys):
+        mock_sys.platform = "win32"
+        cmd = get_audio_play_command("/tmp/audio.wav")
+        assert cmd[0] == "powershell"
+        assert "SoundPlayer" in cmd[-1]
+
+    @patch("neurascreen.platform.sys")
+    def test_unsupported_platform_raises(self, mock_sys):
+        mock_sys.platform = "freebsd"
+        with pytest.raises(RuntimeError, match="Unsupported platform"):
+            get_audio_play_command("/tmp/audio.wav")
+
+
+class TestDependencyChecks:
+    """Tests for dependency checking functions."""
+
+    @patch("neurascreen.platform.shutil")
+    @patch("neurascreen.platform.sys")
+    def test_capture_deps_ok_macos(self, mock_sys, mock_shutil):
+        mock_sys.platform = "darwin"
+        mock_shutil.which = lambda x: "/usr/local/bin/ffmpeg" if x == "ffmpeg" else None
+        assert check_capture_dependencies() == []
+
+    @patch("neurascreen.platform.shutil")
+    @patch("neurascreen.platform.sys")
+    def test_capture_deps_missing_ffmpeg(self, mock_sys, mock_shutil):
+        mock_sys.platform = "darwin"
+        mock_shutil.which = lambda x: None
+        errors = check_capture_dependencies()
+        assert len(errors) == 1
+        assert "ffmpeg" in errors[0]
+
+    @patch.dict("os.environ", {}, clear=True)
+    @patch("neurascreen.platform.shutil")
+    @patch("neurascreen.platform.sys")
+    def test_capture_deps_linux_no_display(self, mock_sys, mock_shutil):
+        mock_sys.platform = "linux"
+        mock_shutil.which = lambda x: "/usr/bin/ffmpeg"
+        errors = check_capture_dependencies()
+        assert any("DISPLAY" in e for e in errors)
+
+    @patch("neurascreen.platform.shutil")
+    @patch("neurascreen.platform.sys")
+    def test_audio_deps_macos_ok(self, mock_sys, mock_shutil):
+        mock_sys.platform = "darwin"
+        mock_shutil.which = lambda x: "/usr/bin/afplay" if x == "afplay" else None
+        assert check_audio_dependencies() == []
+
+    @patch("neurascreen.platform.shutil")
+    @patch("neurascreen.platform.sys")
+    def test_audio_deps_linux_paplay(self, mock_sys, mock_shutil):
+        mock_sys.platform = "linux"
+        mock_shutil.which = lambda x: "/usr/bin/paplay" if x == "paplay" else None
+        assert check_audio_dependencies() == []
+
+    @patch("neurascreen.platform.shutil")
+    @patch("neurascreen.platform.sys")
+    def test_audio_deps_linux_none(self, mock_sys, mock_shutil):
+        mock_sys.platform = "linux"
+        mock_shutil.which = lambda x: None
+        errors = check_audio_dependencies()
+        assert len(errors) == 1

--- a/tests/test_tts.py
+++ b/tests/test_tts.py
@@ -36,6 +36,7 @@ def _make_config(provider: str = "gradium", **overrides) -> Config:
         video_height=1080,
         video_fps=30,
         capture_screen=0,
+        capture_display="",
         browser_screen_offset=0,
         tts_provider=provider,
         tts_api_key="test-key",


### PR DESCRIPTION
## Summary

- Add `neurascreen/platform.py` module with OS detection and platform-specific command builders
- **Linux**: screen capture via ffmpeg `x11grab`, audio playback via `paplay` (PulseAudio) or `aplay` (ALSA)
- **Windows**: screen capture via ffmpeg `gdigrab`, audio playback via PowerShell `SoundPlayer`
- **macOS**: unchanged behavior (avfoundation + afplay)
- New `CAPTURE_DISPLAY` config variable for Linux/Windows display targeting
- 29 new unit tests for platform module (113 total, all passing)

## Changes

| File | Change |
|------|--------|
| `neurascreen/platform.py` | **New** — OS detection, capture/audio command builders, dependency checks |
| `neurascreen/recorder.py` | Uses `get_capture_command()` instead of hardcoded avfoundation |
| `neurascreen/browser.py` | Uses `get_audio_play_command()` instead of hardcoded afplay |
| `neurascreen/config.py` | Add `capture_display` field |
| `neurascreen/assembler.py` | Cross-platform ffmpeg install message |
| `pyproject.toml` | Version 1.2.0, Windows classifier |
| `.env.example` | Document `CAPTURE_DISPLAY` |
| `README.md` | Platform badges, support table, new config docs |
| `ROADMAP.md` | Mark v1.1 and v1.2 complete |
| `tests/test_platform.py` | **New** — 29 tests |

## Closes

Closes #1 — Linux screen capture via x11grab
Closes #2 — Linux audio playback via aplay/paplay
Closes #8 — Windows screen capture via gdigrab

## Test plan

- [x] 113 unit tests passing (84 existing + 29 new)
- [ ] Manual test on Linux with X11 display
- [ ] Manual test on Windows with gdigrab