### PR TITLE
feat: SRT subtitles, YouTube chapters and batch mode (v1.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NeuraScreen
 
-![Version](https://img.shields.io/badge/version-1.2.0-blue)
+![Version](https://img.shields.io/badge/version-1.3.0-blue)
 ![PyPI](https://img.shields.io/badge/pip_install-neurascreen-3775A9?logo=pypi&logoColor=white)
 ![Python](https://img.shields.io/badge/python-3.12+-3776AB?logo=python&logoColor=white)
 ![Playwright](https://img.shields.io/badge/playwright-1.52-2EAD33?logo=playwright&logoColor=white)
@@ -357,10 +357,11 @@ All settings are in `.env`. See [`.env.example`](.env.example) for the full docu
 | `neurascreen preview <file>` | Run in browser without recording |
 | `neurascreen run <file>` | Record video without narration |
 | `neurascreen full <file>` | Record with TTS narration |
+| `neurascreen batch <folder>` | Generate videos from all scenarios in a folder |
 | `neurascreen list` | List available scenarios |
 | `neurascreen --version` | Show version |
 
-Options: `--verbose` / `-v` for debug output, `--headless` for headless mode.
+Options: `--verbose` / `-v` for debug output, `--headless` for headless mode, `--srt` for subtitle generation, `--chapters` for YouTube chapter markers.
 
 You can also use `python -m neurascreen` instead of `neurascreen`.
 
@@ -401,6 +402,7 @@ neurascreen/
 │   ├── browser.py        # Playwright browser engine
 │   ├── platform.py       # OS detection & platform-specific commands
 │   ├── recorder.py       # Screen capture (ffmpeg)
+│   ├── subtitles.py      # SRT subtitles & YouTube chapters
 │   ├── narrator.py       # TTS & timing sync
 │   ├── tts.py            # TTS abstraction (5 providers)
 │   ├── assembler.py      # Video assembly

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,9 +29,9 @@
 
 ## v1.3 — Production features
 
-- [ ] Subtitle generation (SRT) from narration timestamps (#10)
-- [ ] YouTube chapter markers from scenario step titles (#11)
-- [ ] Batch mode: generate multiple videos from a folder (#12)
+- [x] Subtitle generation (SRT) from narration timestamps (#10)
+- [x] YouTube chapter markers from scenario step titles (#11)
+- [x] Batch mode: generate multiple videos from a folder (#12)
 
 ## v1.4 — Advanced
 

--- a/neurascreen/__init__.py
+++ b/neurascreen/__init__.py
@@ -1,3 +1,3 @@
 """NeuraScreen — Automated screen walkthrough video generator."""
 
-__version__ = "1.2.0"
+__version__ = "1.3.0"

--- a/neurascreen/cli.py
+++ b/neurascreen/cli.py
@@ -12,7 +12,41 @@ from .config import Config
 from .scenario import parse_scenario, validate_scenario
 from .recorder import Recorder
 from .assembler import Assembler
+from .subtitles import generate_srt, generate_chapters
 from .utils import setup_logger, format_duration
+
+
+def _collect_narrations(scenario) -> dict[int, str]:
+    """Collect narration texts keyed by step index."""
+    return {
+        i: step.narration
+        for i, step in enumerate(scenario.steps)
+        if step.narration and step.narration.strip()
+    }
+
+
+def _collect_narrated_titles(scenario) -> list[str]:
+    """Collect step titles for narrated steps only."""
+    return [
+        step.title or f"Section {i + 1}"
+        for i, step in enumerate(scenario.steps)
+        if step.narration and step.narration.strip()
+    ]
+
+
+def _generate_extras(
+    audio_timestamps, scenario, output_stem: Path, srt: bool, chapters: bool
+) -> None:
+    """Generate SRT and/or chapter files alongside the video."""
+    if srt and audio_timestamps:
+        narrations = _collect_narrations(scenario)
+        srt_path = output_stem.with_suffix(".srt")
+        generate_srt(audio_timestamps, narrations, srt_path)
+
+    if chapters and audio_timestamps:
+        titles = _collect_narrated_titles(scenario)
+        chapters_path = output_stem.with_suffix(".chapters.txt")
+        generate_chapters(audio_timestamps, titles, chapters_path)
 
 
 @click.group()
@@ -30,8 +64,10 @@ def cli(ctx: click.Context, verbose: bool, headless: bool) -> None:
 @cli.command()
 @click.argument("scenario_path", type=click.Path(exists=True))
 @click.option("--output", "-o", type=click.Path(), help="Output MP4 path")
+@click.option("--srt", is_flag=True, help="Generate SRT subtitle file")
+@click.option("--chapters", is_flag=True, help="Generate YouTube chapter markers")
 @click.pass_context
-def run(ctx: click.Context, scenario_path: str, output: str | None) -> None:
+def run(ctx: click.Context, scenario_path: str, output: str | None, srt: bool, chapters: bool) -> None:
     """Execute a scenario and generate a video (without narration)."""
     config = Config.load()
     if ctx.obj["headless"]:
@@ -51,7 +87,7 @@ def run(ctx: click.Context, scenario_path: str, output: str | None) -> None:
         logger.info(f"Scenario: {scenario.title} ({len(scenario.steps)} steps)")
 
         recorder = Recorder(config)
-        raw_video, _ = recorder.record(scenario)
+        raw_video, audio_timestamps = recorder.record(scenario)
 
         if not raw_video or not raw_video.exists():
             logger.error("No video file produced")
@@ -64,6 +100,8 @@ def run(ctx: click.Context, scenario_path: str, output: str | None) -> None:
             output_path=Path(output) if output else None,
         )
         assembler.cleanup_temp()
+
+        _generate_extras(audio_timestamps, scenario, mp4_path, srt, chapters)
 
         elapsed = time.time() - start_time
         logger.info(f"Done in {format_duration(int(elapsed * 1000))}. Output: {mp4_path}")
@@ -79,8 +117,10 @@ def run(ctx: click.Context, scenario_path: str, output: str | None) -> None:
 @cli.command()
 @click.argument("scenario_path", type=click.Path(exists=True))
 @click.option("--output", "-o", type=click.Path(), help="Output MP4 path")
+@click.option("--srt", is_flag=True, help="Generate SRT subtitle file")
+@click.option("--chapters", is_flag=True, help="Generate YouTube chapter markers")
 @click.pass_context
-def full(ctx: click.Context, scenario_path: str, output: str | None) -> None:
+def full(ctx: click.Context, scenario_path: str, output: str | None, srt: bool, chapters: bool) -> None:
     """Execute a scenario with TTS narration and generate a video."""
     config = Config.load()
     if ctx.obj["headless"]:
@@ -129,6 +169,8 @@ def full(ctx: click.Context, scenario_path: str, output: str | None) -> None:
 
         assembler.cleanup_temp()
 
+        _generate_extras(audio_timestamps, scenario, final_path, srt, chapters)
+
         elapsed = time.time() - start_time
         logger.info(f"Done in {format_duration(int(elapsed * 1000))}. Output: {final_path}")
 
@@ -164,6 +206,131 @@ def preview(ctx: click.Context, scenario_path: str) -> None:
         sys.exit(130)
     except Exception as e:
         logger.error(f"Error: {e}")
+        sys.exit(1)
+
+
+@cli.command("batch")
+@click.argument("folder_path", type=click.Path(exists=True, file_okay=False))
+@click.option("--srt", is_flag=True, help="Generate SRT subtitle files")
+@click.option("--chapters", is_flag=True, help="Generate YouTube chapter markers")
+@click.option("--narration/--no-narration", default=True, help="Enable TTS narration (default: on)")
+@click.pass_context
+def batch(ctx: click.Context, folder_path: str, srt: bool, chapters: bool, narration: bool) -> None:
+    """Generate videos from all scenarios in a folder."""
+    config = Config.load()
+    if ctx.obj["headless"]:
+        config.browser_headless = True
+
+    logger = setup_logger("videogen", config.logs_dir, ctx.obj["verbose"])
+
+    if narration:
+        errors = config.validate_tts()
+    else:
+        errors = config.validate()
+    if errors:
+        for e in errors:
+            logger.error(e)
+        sys.exit(1)
+
+    folder = Path(folder_path)
+    scenario_files = sorted(folder.rglob("*.json"))
+
+    if not scenario_files:
+        click.echo(f"No scenario files found in {folder}")
+        sys.exit(1)
+
+    # Validate all scenarios first
+    valid_files = []
+    for sf in scenario_files:
+        try:
+            with open(sf, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            errs = validate_scenario(data)
+            if errs:
+                logger.warning(f"Skipping {sf.name}: {len(errs)} validation errors")
+                for e in errs:
+                    logger.warning(f"  - {e}")
+            else:
+                valid_files.append(sf)
+        except json.JSONDecodeError as e:
+            logger.warning(f"Skipping {sf.name}: invalid JSON ({e})")
+
+    if not valid_files:
+        click.echo("No valid scenarios found")
+        sys.exit(1)
+
+    click.echo(f"Batch: {len(valid_files)} scenarios to process\n")
+
+    results: list[tuple[str, str, str]] = []  # (name, status, detail)
+    batch_start = time.time()
+
+    for i, sf in enumerate(valid_files, 1):
+        click.echo(f"[{i}/{len(valid_files)}] {sf.name}")
+        scenario_start = time.time()
+
+        try:
+            scenario = parse_scenario(str(sf))
+
+            if narration:
+                from .narrator import Narrator
+                narrator_inst = Narrator(config)
+                scenario, audio_map = narrator_inst.prepare_narration(scenario)
+            else:
+                audio_map = None
+
+            recorder = Recorder(config)
+            raw_video, audio_timestamps = recorder.record(
+                scenario, audio_map=audio_map if audio_map else None
+            )
+
+            if not raw_video or not raw_video.exists():
+                results.append((sf.name, "FAIL", "No video produced"))
+                continue
+
+            assembler = Assembler(config)
+            final_name = sf.stem + ".mp4"
+            final_path = config.output_dir / final_name
+
+            if narration and audio_timestamps:
+                video_duration = assembler.get_video_duration(raw_video)
+                narration_wav = assembler.build_audio_from_timestamps(
+                    audio_timestamps, video_duration
+                )
+                temp_mp4 = config.temp_dir / "video_only.mp4"
+                assembler.convert_to_mp4(raw_video, output_path=temp_mp4)
+                assembler.assemble_with_audio(temp_mp4, narration_wav, final_path)
+            else:
+                final_path = assembler.convert_to_mp4(
+                    raw_video, output_name=scenario.title
+                )
+
+            assembler.cleanup_temp()
+
+            _generate_extras(audio_timestamps, scenario, final_path, srt, chapters)
+
+            elapsed = time.time() - scenario_start
+            size_mb = final_path.stat().st_size / (1024 * 1024)
+            results.append((sf.name, "OK", f"{size_mb:.1f} MB in {format_duration(int(elapsed * 1000))}"))
+
+        except KeyboardInterrupt:
+            logger.info("Batch interrupted by user")
+            results.append((sf.name, "SKIP", "Interrupted"))
+            break
+        except Exception as e:
+            logger.error(f"  Failed: {e}")
+            results.append((sf.name, "FAIL", str(e)[:80]))
+
+    # Summary
+    batch_elapsed = time.time() - batch_start
+    click.echo(f"\n{'='*60}")
+    click.echo(f"Batch complete: {len(results)}/{len(valid_files)} processed in {format_duration(int(batch_elapsed * 1000))}\n")
+    for name, status, detail in results:
+        icon = "+" if status == "OK" else "-" if status == "FAIL" else "~"
+        click.echo(f"  [{icon}] {name:<40} {detail}")
+
+    failed = sum(1 for _, s, _ in results if s == "FAIL")
+    if failed:
+        click.echo(f"\n{failed} failed")
         sys.exit(1)
 
 

--- a/neurascreen/subtitles.py
+++ b/neurascreen/subtitles.py
@@ -1,0 +1,113 @@
+"""Subtitle (SRT) and YouTube chapter marker generation."""
+
+import logging
+from pathlib import Path
+
+from .tts import get_wav_duration_ms
+
+logger = logging.getLogger("videogen")
+
+
+def _format_srt_time(seconds: float) -> str:
+    """Format seconds to SRT timestamp: HH:MM:SS,mmm."""
+    hours = int(seconds // 3600)
+    minutes = int((seconds % 3600) // 60)
+    secs = int(seconds % 60)
+    millis = int((seconds % 1) * 1000)
+    return f"{hours:02d}:{minutes:02d}:{secs:02d},{millis:03d}"
+
+
+def _format_chapter_time(seconds: float) -> str:
+    """Format seconds to YouTube chapter timestamp: HH:MM:SS or MM:SS."""
+    hours = int(seconds // 3600)
+    minutes = int((seconds % 3600) // 60)
+    secs = int(seconds % 60)
+    if hours > 0:
+        return f"{hours:02d}:{minutes:02d}:{secs:02d}"
+    return f"{minutes:02d}:{secs:02d}"
+
+
+def generate_srt(
+    audio_timestamps: list[tuple[float, Path]],
+    narrations: dict[int, str],
+    output_path: Path,
+) -> Path:
+    """Generate an SRT subtitle file from audio timestamps and narration texts.
+
+    Args:
+        audio_timestamps: List of (seconds_from_start, wav_path) tuples.
+        narrations: Map of step_index -> narration text.
+        output_path: Path for the output .srt file.
+
+    Returns:
+        Path to the generated SRT file.
+    """
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Build subtitle entries: match timestamps with narration texts
+    # narrations keys are step indices, audio_timestamps are ordered by time
+    narration_texts = list(narrations.values())
+    entries = []
+
+    for i, (start_s, wav_path) in enumerate(audio_timestamps):
+        if i >= len(narration_texts):
+            break
+        duration_ms = get_wav_duration_ms(wav_path)
+        end_s = start_s + duration_ms / 1000
+        text = narration_texts[i]
+        entries.append((start_s, end_s, text))
+
+    with open(output_path, "w", encoding="utf-8") as f:
+        for idx, (start_s, end_s, text) in enumerate(entries, 1):
+            f.write(f"{idx}\n")
+            f.write(f"{_format_srt_time(start_s)} --> {_format_srt_time(end_s)}\n")
+            f.write(f"{text}\n")
+            f.write("\n")
+
+    logger.info(f"SRT subtitles: {output_path} ({len(entries)} entries)")
+    return output_path
+
+
+def generate_chapters(
+    audio_timestamps: list[tuple[float, Path]],
+    step_titles: list[str],
+    output_path: Path,
+) -> Path:
+    """Generate a YouTube chapter markers file from timestamps and step titles.
+
+    The output format is one chapter per line: "MM:SS Title"
+    YouTube requires the first chapter to start at 00:00.
+
+    Args:
+        audio_timestamps: List of (seconds_from_start, wav_path) tuples.
+        step_titles: Titles corresponding to each narrated step.
+        output_path: Path for the output .chapters.txt file.
+
+    Returns:
+        Path to the generated chapters file.
+    """
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    chapters = []
+    for i, (start_s, _) in enumerate(audio_timestamps):
+        if i >= len(step_titles):
+            break
+        title = step_titles[i].strip()
+        if not title:
+            title = f"Section {i + 1}"
+        chapters.append((start_s, title))
+
+    if not chapters:
+        logger.info("No chapters to generate")
+        return output_path
+
+    # YouTube requires first chapter at 00:00
+    if chapters[0][0] > 0.5:
+        chapters.insert(0, (0.0, "Introduction"))
+
+    with open(output_path, "w", encoding="utf-8") as f:
+        for start_s, title in chapters:
+            f.write(f"{_format_chapter_time(start_s)} {title}\n")
+
+    logger.info(f"YouTube chapters: {output_path} ({len(chapters)} chapters)")
+    return output_path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "neurascreen"
-version = "1.2.0"
+version = "1.3.0"
 description = "Automated screen walkthrough video generator using Playwright, JSON scenarios and Text-to-Speech"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_subtitles.py
+++ b/tests/test_subtitles.py
@@ -1,0 +1,207 @@
+"""Tests for subtitle (SRT) and YouTube chapter generation."""
+
+import wave
+from pathlib import Path
+
+import pytest
+
+from neurascreen.subtitles import (
+    _format_srt_time,
+    _format_chapter_time,
+    generate_srt,
+    generate_chapters,
+)
+
+
+def _create_wav(path: Path, duration_s: float = 1.0, rate: int = 48000) -> Path:
+    """Create a valid WAV file with the given duration."""
+    n_frames = int(rate * duration_s)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with wave.open(str(path), "w") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(rate)
+        wf.writeframes(b"\x00\x00" * n_frames)
+    return path
+
+
+class TestFormatSrtTime:
+    """Tests for SRT timestamp formatting."""
+
+    def test_zero(self):
+        assert _format_srt_time(0.0) == "00:00:00,000"
+
+    def test_seconds_only(self):
+        assert _format_srt_time(5.5) == "00:00:05,500"
+
+    def test_minutes(self):
+        assert _format_srt_time(65.123) == "00:01:05,123"
+
+    def test_hours(self):
+        assert _format_srt_time(3661.0) == "01:01:01,000"
+
+    def test_millis_precision(self):
+        assert _format_srt_time(1.999) == "00:00:01,999"
+
+
+class TestFormatChapterTime:
+    """Tests for YouTube chapter timestamp formatting."""
+
+    def test_zero(self):
+        assert _format_chapter_time(0.0) == "00:00"
+
+    def test_minutes(self):
+        assert _format_chapter_time(125.0) == "02:05"
+
+    def test_hours(self):
+        assert _format_chapter_time(3661.0) == "01:01:01"
+
+    def test_no_hours_prefix(self):
+        # Under 1 hour should use MM:SS format
+        assert _format_chapter_time(59.0) == "00:59"
+
+
+class TestGenerateSrt:
+    """Tests for SRT file generation."""
+
+    def test_basic_srt(self, tmp_path):
+        wav1 = _create_wav(tmp_path / "audio" / "step1.wav", 2.0)
+        wav2 = _create_wav(tmp_path / "audio" / "step2.wav", 3.0)
+
+        timestamps = [(5.0, wav1), (10.0, wav2)]
+        narrations = {0: "First narration.", 3: "Second narration."}
+        output = tmp_path / "output.srt"
+
+        result = generate_srt(timestamps, narrations, output)
+
+        assert result.exists()
+        content = result.read_text(encoding="utf-8")
+        assert "1\n" in content
+        assert "2\n" in content
+        assert "First narration." in content
+        assert "Second narration." in content
+        assert "-->" in content
+
+    def test_empty_timestamps(self, tmp_path):
+        output = tmp_path / "output.srt"
+        result = generate_srt([], {}, output)
+        assert result.exists()
+        assert result.read_text(encoding="utf-8") == ""
+
+    def test_srt_timing_format(self, tmp_path):
+        wav = _create_wav(tmp_path / "step.wav", 1.5)
+        timestamps = [(2.0, wav)]
+        narrations = {0: "Test."}
+        output = tmp_path / "output.srt"
+
+        generate_srt(timestamps, narrations, output)
+        content = output.read_text(encoding="utf-8")
+
+        assert "00:00:02,000 --> 00:00:03,500" in content
+
+    def test_srt_entry_count(self, tmp_path):
+        wavs = [_create_wav(tmp_path / f"s{i}.wav", 1.0) for i in range(5)]
+        timestamps = [(i * 3.0, w) for i, w in enumerate(wavs)]
+        narrations = {i: f"Narration {i}" for i in range(5)}
+        output = tmp_path / "output.srt"
+
+        generate_srt(timestamps, narrations, output)
+        content = output.read_text(encoding="utf-8")
+
+        # Count subtitle entries (each starts with a number on its own line)
+        entries = [line for line in content.strip().split("\n") if line.strip().isdigit()]
+        assert len(entries) == 5
+
+    def test_creates_parent_dir(self, tmp_path):
+        wav = _create_wav(tmp_path / "audio.wav", 1.0)
+        output = tmp_path / "deep" / "nested" / "output.srt"
+        generate_srt([(1.0, wav)], {0: "Test."}, output)
+        assert output.exists()
+
+
+class TestGenerateChapters:
+    """Tests for YouTube chapter marker generation."""
+
+    def test_basic_chapters(self, tmp_path):
+        wav1 = _create_wav(tmp_path / "s1.wav", 1.0)
+        wav2 = _create_wav(tmp_path / "s2.wav", 1.0)
+
+        timestamps = [(5.0, wav1), (30.0, wav2)]
+        titles = ["Dashboard Overview", "Settings Page"]
+        output = tmp_path / "chapters.txt"
+
+        result = generate_chapters(timestamps, titles, output)
+
+        assert result.exists()
+        content = result.read_text(encoding="utf-8")
+        lines = content.strip().split("\n")
+
+        # First chapter should be at 00:00 (auto-inserted Introduction)
+        assert lines[0] == "00:00 Introduction"
+        assert "00:05 Dashboard Overview" in content
+        assert "00:30 Settings Page" in content
+
+    def test_chapter_at_zero_no_extra_intro(self, tmp_path):
+        wav = _create_wav(tmp_path / "s.wav", 1.0)
+
+        timestamps = [(0.0, wav)]
+        titles = ["Intro"]
+        output = tmp_path / "chapters.txt"
+
+        generate_chapters(timestamps, titles, output)
+        content = output.read_text(encoding="utf-8")
+        lines = content.strip().split("\n")
+
+        # Should NOT add extra Introduction since first chapter is at 0
+        assert len(lines) == 1
+        assert lines[0] == "00:00 Intro"
+
+    def test_empty_title_gets_default(self, tmp_path):
+        wav = _create_wav(tmp_path / "s.wav", 1.0)
+
+        timestamps = [(5.0, wav)]
+        titles = [""]
+        output = tmp_path / "chapters.txt"
+
+        generate_chapters(timestamps, titles, output)
+        content = output.read_text(encoding="utf-8")
+
+        assert "Section 1" in content
+
+    def test_empty_timestamps(self, tmp_path):
+        output = tmp_path / "chapters.txt"
+        generate_chapters([], [], output)
+        # File may or may not exist, but no crash
+        assert True
+
+    def test_more_timestamps_than_titles(self, tmp_path):
+        wavs = [_create_wav(tmp_path / f"s{i}.wav", 1.0) for i in range(3)]
+        timestamps = [(i * 10.0, w) for i, w in enumerate(wavs)]
+        titles = ["Only One"]
+        output = tmp_path / "chapters.txt"
+
+        generate_chapters(timestamps, titles, output)
+        content = output.read_text(encoding="utf-8")
+
+        # First timestamp is at 0.0, so no extra Introduction inserted
+        # Should only generate chapters for available titles
+        lines = [l for l in content.strip().split("\n") if l.strip()]
+        assert len(lines) == 1
+        assert "Only One" in lines[0]
+
+    def test_creates_parent_dir(self, tmp_path):
+        wav = _create_wav(tmp_path / "s.wav", 1.0)
+        output = tmp_path / "deep" / "nested" / "chapters.txt"
+        generate_chapters([(1.0, wav)], ["Test"], output)
+        assert output.exists()
+
+    def test_hour_format(self, tmp_path):
+        wav = _create_wav(tmp_path / "s.wav", 1.0)
+        timestamps = [(3700.0, wav)]
+        titles = ["Late Chapter"]
+        output = tmp_path / "chapters.txt"
+
+        generate_chapters(timestamps, titles, output)
+        content = output.read_text(encoding="utf-8")
+
+        assert "01:01:40 Late Chapter" in content


### PR DESCRIPTION
## Summary

- **SRT subtitles** (`--srt`): generates `.srt` file alongside video from narration timestamps
- **YouTube chapters** (`--chapters`): generates `.chapters.txt` with timestamps from step titles
- **Batch mode** (`neurascreen batch <folder>`): processes all JSON scenarios in a folder sequentially with summary report

## Changes

| File | Change |
|------|--------|
| `neurascreen/subtitles.py` | **New** — SRT generation + YouTube chapter markers |
| `neurascreen/cli.py` | `--srt` and `--chapters` flags on `run`/`full`, new `batch` command |
| `tests/test_subtitles.py` | **New** — 21 tests (SRT format, chapters, edge cases) |
| `pyproject.toml` | Version 1.3.0 |
| `README.md` | Updated CLI table, version badge, project structure |
| `ROADMAP.md` | Mark v1.3 complete |

## Usage

```bash
# Video + subtitles + chapters
neurascreen full --srt --chapters scenario.json

# Batch all scenarios in a folder
neurascreen batch scenarios/ --srt --chapters

# Batch without narration
neurascreen batch scenarios/ --no-narration
```

## Closes

Closes #10 — Subtitle generation (SRT) from narration timestamps
Closes #11 — YouTube chapter markers from scenario step titles
Closes #12 — Batch mode: generate multiple videos from a folder

## Test plan

- [x] 134 unit tests passing (113 existing + 21 new)
- [ ] Manual test: generate SRT and verify sync with video
- [ ] Manual test: paste chapters in YouTube description
- [ ] Manual test: batch mode on folder with multiple scenarios