### PR TITLE
chore: gitignore SRT and chapter files in output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ dist/
 build/
 output/*.mp4
 output/*.mkv
+output/*.srt
+output/*.chapters.txt
 output/*.youtube.md
 temp/
 logs/


### PR DESCRIPTION
Add output/*.srt and output/*.chapters.txt to .gitignore (generated files from v1.3).