### PR TITLE
feat: macro recorder, Docker container and documentation (v1.4)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.venv/
+.env
+__pycache__/
+*.pyc
+*.egg-info/
+dist/
+build/
+output/
+temp/
+logs/
+scenarios/
+tests/
+.git/
+.github/
+SESSION.md

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ build/
 output/*.mp4
 output/*.mkv
 output/*.srt
+output/*.json
 output/*.chapters.txt
 output/*.youtube.md
 temp/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,14 +21,14 @@ Open an issue with the `enhancement` label. Describe the use case and why it wou
 1. Fork the repository
 2. Create a feature branch: `git checkout -b my-feature`
 3. Make your changes
-4. Test locally: `python -m src validate examples/01-simple-navigation.json`
+4. Test locally: `neurascreen validate examples/01-simple-navigation.json`
 5. Commit: `git commit -m "Add my feature"`
 6. Push: `git push origin my-feature`
 7. Open a pull request
 
 ## Adding a TTS provider
 
-TTS providers are defined in `src/tts.py`.
+TTS providers are defined in `neurascreen/tts.py`.
 
 1. Create a new class extending `BaseTTSClient`
 2. Implement the `_synthesize(text: str) -> bytes` method (must return WAV audio bytes)
@@ -47,9 +47,9 @@ class MyTTSClient(BaseTTSClient):
 
 ## Adding a scenario action
 
-Actions are defined in `src/browser.py` in the `_do_step()` method.
+Actions are defined in `neurascreen/browser.py` in the `_do_step()` method.
 
-1. Add your action name to `VALID_ACTIONS` in `src/scenario.py`
+1. Add your action name to `VALID_ACTIONS` in `neurascreen/scenario.py`
 2. Add validation rules in `validate_scenario()` if needed
 3. Implement the action in `_do_step()` using a `case` block
 4. Document the action in the README actions table

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,54 @@
+FROM python:3.12-slim
+
+LABEL maintainer="NEURASCOPE <contact@neurascope.ai>"
+LABEL description="NeuraScreen — Automated demo video generator (headless)"
+
+# System dependencies: ffmpeg, Xvfb, and Playwright browser deps
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ffmpeg \
+    xvfb \
+    xauth \
+    libnss3 \
+    libatk-bridge2.0-0 \
+    libdrm2 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxrandr2 \
+    libgbm1 \
+    libasound2 \
+    libpangocairo-1.0-0 \
+    libgtk-3-0 \
+    libx11-xcb1 \
+    libxshmfence1 \
+    fonts-liberation \
+    fonts-noto-color-emoji \
+    pulseaudio \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Install NeuraScreen
+COPY pyproject.toml README.md LICENSE ./
+COPY neurascreen/ ./neurascreen/
+RUN pip install --no-cache-dir ".[all]"
+
+# Install Playwright Chromium
+RUN playwright install chromium
+
+# Copy examples and entrypoint
+COPY examples/ ./examples/
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+# Output and temp directories
+RUN mkdir -p /app/output /app/temp /app/logs
+
+# Default env for headless operation
+ENV BROWSER_HEADLESS=true
+ENV DISPLAY=:99
+ENV OUTPUT_DIR=/app/output
+ENV TEMP_DIR=/app/temp
+ENV LOGS_DIR=/app/logs
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NeuraScreen
 
-![Version](https://img.shields.io/badge/version-1.3.0-blue)
+![Version](https://img.shields.io/badge/version-1.4.0-blue)
 ![PyPI](https://img.shields.io/badge/pip_install-neurascreen-3775A9?logo=pypi&logoColor=white)
 ![Python](https://img.shields.io/badge/python-3.12+-3776AB?logo=python&logoColor=white)
 ![Playwright](https://img.shields.io/badge/playwright-1.52-2EAD33?logo=playwright&logoColor=white)
@@ -358,6 +358,7 @@ All settings are in `.env`. See [`.env.example`](.env.example) for the full docu
 | `neurascreen run <file>` | Record video without narration |
 | `neurascreen full <file>` | Record with TTS narration |
 | `neurascreen batch <folder>` | Generate videos from all scenarios in a folder |
+| `neurascreen record <url>` | Record browser interactions → JSON scenario |
 | `neurascreen list` | List available scenarios |
 | `neurascreen --version` | Show version |
 
@@ -403,6 +404,7 @@ neurascreen/
 │   ├── platform.py       # OS detection & platform-specific commands
 │   ├── recorder.py       # Screen capture (ffmpeg)
 │   ├── subtitles.py      # SRT subtitles & YouTube chapters
+│   ├── macro.py          # Macro recorder (browser → JSON)
 │   ├── narrator.py       # TTS & timing sync
 │   ├── tts.py            # TTS abstraction (5 providers)
 │   ├── assembler.py      # Video assembly
@@ -429,13 +431,102 @@ neurascreen/
 
 ---
 
+## Macro Recorder
+
+Generate scenarios by recording your browser interactions instead of writing JSON by hand:
+
+```bash
+neurascreen record http://localhost:3000 -t "My demo"
+```
+
+A browser opens. Click around normally. Close it when done. The tool outputs a valid JSON scenario.
+
+```bash
+# Review and edit the generated scenario
+neurascreen validate output/my_demo.json
+neurascreen preview output/my_demo.json
+
+# Add narration to wait steps, then generate the video
+neurascreen full output/my_demo.json
+```
+
+See [docs/macro-recorder.md](docs/macro-recorder.md) for the full guide.
+
+---
+
+## Subtitles & YouTube Chapters
+
+Generate SRT subtitles and YouTube chapter markers alongside your videos:
+
+```bash
+# Video + subtitles + chapters
+neurascreen full --srt --chapters scenario.json
+```
+
+Output:
+- `output/scenario.mp4` — the video
+- `output/scenario.srt` — subtitles (upload to YouTube Studio or use with VLC)
+- `output/scenario.chapters.txt` — chapter markers (paste into YouTube description)
+
+See [docs/subtitles-chapters.md](docs/subtitles-chapters.md) for details.
+
+---
+
+## Batch Mode
+
+Process all scenarios in a folder in one command:
+
+```bash
+# With narration
+neurascreen batch scenarios/ --srt --chapters
+
+# Without narration (faster)
+neurascreen batch scenarios/ --no-narration
+```
+
+Validates all scenarios upfront, processes them sequentially, and prints a summary report.
+
+---
+
+## Docker
+
+Run NeuraScreen in a container for headless video generation (no display required):
+
+```bash
+# Build
+docker build -t neurascreen .
+
+# Generate a video
+docker run --rm \
+  -v ./scenarios:/app/examples \
+  -v ./output:/app/output \
+  -e APP_URL=http://host.docker.internal:3000 \
+  -e TTS_PROVIDER=openai -e TTS_API_KEY=sk-... -e TTS_VOICE_ID=alloy \
+  neurascreen full examples/demo.json --srt --chapters
+```
+
+The container includes Xvfb (virtual display) and PulseAudio (audio playback). See [docs/docker.md](docs/docker.md) for CI/CD integration, networking and troubleshooting.
+
+---
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for how to report bugs, suggest features, add TTS providers or submit pull requests.
 
+## Documentation
+
+| Guide | Description |
+|-------|-------------|
+| [Scenario Writing Guide](docs/scenario-guide.md) | How to write effective demo scenarios |
+| [Cross-Platform Setup](docs/cross-platform.md) | macOS, Linux and Windows configuration |
+| [Macro Recorder](docs/macro-recorder.md) | Record browser interactions → JSON |
+| [Subtitles & Chapters](docs/subtitles-chapters.md) | SRT subtitles and YouTube chapters |
+| [Docker](docs/docker.md) | Headless generation in containers |
+| [Contributing](CONTRIBUTING.md) | Add TTS providers, actions, or submit PRs |
+
 ## Roadmap
 
-See [ROADMAP.md](ROADMAP.md) for planned features including Linux/Windows support, macro recorder, PyPI publication and more.
+See [ROADMAP.md](ROADMAP.md) for planned features.
 
 ## License
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -35,8 +35,8 @@
 
 ## v1.4 — Advanced
 
-- [ ] Macro recorder: record browser interactions → JSON scenario (#9)
-- [ ] Docker container for headless generation (#13)
+- [x] Macro recorder: record browser interactions → JSON scenario (#9)
+- [x] Docker container for headless generation (#13)
 
 ## Future Ideas
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+# Start Xvfb virtual framebuffer for headless screen capture
+Xvfb :99 -screen 0 1920x1080x24 -ac +extension GLX +render -noreset &
+XVFB_PID=$!
+
+# Wait for Xvfb to be ready
+sleep 1
+
+# Start PulseAudio for audio playback (needed by paplay)
+pulseaudio --start --exit-idle-time=-1 2>/dev/null || true
+
+# Run neurascreen with all arguments
+exec neurascreen "$@"

--- a/docs/cross-platform.md
+++ b/docs/cross-platform.md
@@ -1,0 +1,156 @@
+# Cross-Platform Support
+
+NeuraScreen runs on macOS, Linux and Windows. This guide covers platform-specific setup.
+
+## Platform support matrix
+
+| Feature | macOS | Linux | Windows |
+|---------|-------|-------|---------|
+| Browser automation (Playwright) | Yes | Yes | Yes |
+| Screen capture | avfoundation | x11grab | gdigrab |
+| Audio playback | afplay | paplay / aplay | PowerShell |
+| TTS generation | Yes | Yes | Yes |
+| Video assembly (ffmpeg) | Yes | Yes | Yes |
+
+Platform is detected automatically — no configuration needed for single-monitor setups.
+
+## macOS
+
+### Install
+
+```bash
+brew install ffmpeg
+pip install neurascreen
+playwright install chromium
+```
+
+### Multi-monitor
+
+```env
+# ffmpeg avfoundation screen index
+# Find yours: ffmpeg -f avfoundation -list_devices true -i ""
+CAPTURE_SCREEN=1
+
+# X pixel offset to position browser on the target screen
+# Each 2560px screen adds 2560 (e.g. screen 2 = 5120)
+BROWSER_SCREEN_OFFSET=5120
+```
+
+**Note**: ffmpeg screen indices do NOT match macOS System Preferences order. Capture one frame per screen to identify the correct index.
+
+---
+
+## Linux
+
+### Install
+
+```bash
+# System dependencies
+sudo apt install ffmpeg pulseaudio alsa-utils
+
+# NeuraScreen
+pip install neurascreen
+playwright install chromium
+```
+
+### Screen capture (x11grab)
+
+NeuraScreen uses `ffmpeg -f x11grab` on Linux. This requires an X11 display.
+
+```env
+# X11 display (default: :0.0)
+CAPTURE_DISPLAY=:0.0
+
+# Capture a specific region (offset from top-left)
+CAPTURE_DISPLAY=:0.0+100,200
+```
+
+### Audio playback
+
+NeuraScreen detects the available player automatically:
+
+1. **paplay** (PulseAudio) — preferred, used if available
+2. **aplay** (ALSA) — fallback
+
+Install at least one:
+
+```bash
+# PulseAudio (recommended)
+sudo apt install pulseaudio
+
+# ALSA (alternative)
+sudo apt install alsa-utils
+```
+
+### Headless Linux (no display)
+
+Use Xvfb to create a virtual display:
+
+```bash
+# Install
+sudo apt install xvfb
+
+# Run NeuraScreen with virtual display
+xvfb-run -s "-screen 0 1920x1080x24" neurascreen full scenario.json
+```
+
+Or use the [Docker container](docker.md) which handles this automatically.
+
+---
+
+## Windows
+
+### Install
+
+```bash
+# Install ffmpeg (via Chocolatey)
+choco install ffmpeg
+
+# Or download from https://ffmpeg.org/download.html and add to PATH
+
+# NeuraScreen
+pip install neurascreen
+playwright install chromium
+```
+
+### Screen capture (gdigrab)
+
+NeuraScreen uses `ffmpeg -f gdigrab` on Windows.
+
+```env
+# Capture full desktop (default)
+CAPTURE_DISPLAY=desktop
+
+# Capture a specific window by title
+CAPTURE_DISPLAY=title=My Application
+```
+
+### Audio playback
+
+Audio is played via PowerShell's `SoundPlayer` (built-in, no extra install needed).
+
+### Known limitations on Windows
+
+- `BROWSER_SCREEN_OFFSET` for multi-monitor positioning works via CDP but window placement may differ from macOS behavior
+- Some ffmpeg features (like cursor capture) may behave differently with gdigrab
+
+---
+
+## Verifying your setup
+
+Check that all dependencies are available:
+
+```bash
+# Verify ffmpeg
+ffmpeg -version
+
+# Verify Playwright
+playwright --version
+
+# Verify NeuraScreen
+neurascreen --version
+
+# Test with an example scenario
+neurascreen validate examples/01-simple-navigation.json
+neurascreen --headless preview examples/01-simple-navigation.json
+```

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,178 @@
+# Docker — Headless Video Generation
+
+Run NeuraScreen in a Docker container without a display. Useful for CI/CD pipelines, servers, and automated video generation.
+
+## Quick start
+
+### Build the image
+
+```bash
+docker build -t neurascreen .
+```
+
+### Generate a video
+
+```bash
+docker run --rm \
+  -v ./scenarios:/app/examples \
+  -v ./output:/app/output \
+  -e APP_URL=http://host.docker.internal:3000 \
+  -e TTS_PROVIDER=openai \
+  -e TTS_API_KEY=sk-... \
+  -e TTS_VOICE_ID=alloy \
+  neurascreen full examples/demo.json --srt --chapters
+```
+
+### Batch mode
+
+```bash
+docker run --rm \
+  -v ./scenarios:/app/examples \
+  -v ./output:/app/output \
+  -e APP_URL=http://host.docker.internal:3000 \
+  neurascreen batch examples/ --no-narration
+```
+
+## How it works
+
+The container includes:
+
+| Component | Purpose |
+|-----------|---------|
+| **Python 3.12** | Runtime |
+| **Playwright + Chromium** | Browser automation |
+| **Xvfb** | Virtual framebuffer (fake display) |
+| **ffmpeg** | Screen capture and video assembly |
+| **PulseAudio** | Audio playback (for narration sync) |
+
+The entrypoint script (`docker-entrypoint.sh`) starts Xvfb and PulseAudio before running NeuraScreen.
+
+## Configuration
+
+Pass environment variables with `-e`:
+
+```bash
+docker run --rm \
+  -e APP_URL=http://host.docker.internal:3000 \
+  -e APP_EMAIL=user@example.com \
+  -e APP_PASSWORD=secret \
+  -e TTS_PROVIDER=openai \
+  -e TTS_API_KEY=sk-... \
+  -e TTS_VOICE_ID=alloy \
+  -e TTS_MODEL=tts-1-hd \
+  -e VIDEO_WIDTH=1920 \
+  -e VIDEO_HEIGHT=1080 \
+  -e VIDEO_FPS=30 \
+  neurascreen full examples/demo.json
+```
+
+Or use an env file:
+
+```bash
+docker run --rm --env-file .env \
+  -v ./scenarios:/app/examples \
+  -v ./output:/app/output \
+  neurascreen full examples/demo.json
+```
+
+## Volumes
+
+| Container path | Purpose |
+|---------------|---------|
+| `/app/examples` | Scenario JSON files (input) |
+| `/app/output` | Generated videos, SRT, chapters (output) |
+| `/app/temp` | Intermediate files (optional, for debugging) |
+| `/app/logs` | Execution logs (optional) |
+
+## Networking
+
+### Access your local app
+
+Use `host.docker.internal` to reach services running on the host:
+
+```bash
+-e APP_URL=http://host.docker.internal:3000
+```
+
+On Linux, you may need `--network host` instead:
+
+```bash
+docker run --rm --network host \
+  -e APP_URL=http://localhost:3000 \
+  ...
+```
+
+### Access remote apps
+
+Point `APP_URL` to the remote server directly:
+
+```bash
+-e APP_URL=https://demo.example.com
+```
+
+## CI/CD integration
+
+### GitHub Actions
+
+```yaml
+jobs:
+  generate-video:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build NeuraScreen
+        run: docker build -t neurascreen .
+
+      - name: Generate demo video
+        run: |
+          docker run --rm \
+            -v ${{ github.workspace }}/scenarios:/app/examples \
+            -v ${{ github.workspace }}/output:/app/output \
+            -e APP_URL=${{ secrets.APP_URL }} \
+            -e TTS_PROVIDER=openai \
+            -e TTS_API_KEY=${{ secrets.TTS_API_KEY }} \
+            -e TTS_VOICE_ID=alloy \
+            neurascreen full examples/demo.json --srt --chapters
+
+      - name: Upload video
+        uses: actions/upload-artifact@v4
+        with:
+          name: demo-video
+          path: output/
+```
+
+## Troubleshooting
+
+### Browser fails to start
+
+Check that Chromium was installed correctly:
+
+```bash
+docker run --rm neurascreen validate examples/01-simple-navigation.json
+```
+
+### No video output
+
+Check the logs:
+
+```bash
+docker run --rm -v ./logs:/app/logs neurascreen -v full examples/demo.json
+cat logs/*.log
+```
+
+### Screen capture is black
+
+Xvfb may not have started. Check the entrypoint:
+
+```bash
+docker run --rm --entrypoint bash neurascreen -c "Xvfb :99 &; sleep 1; DISPLAY=:99 neurascreen preview examples/01-simple-navigation.json"
+```
+
+### App not reachable
+
+Verify connectivity from the container:
+
+```bash
+docker run --rm --entrypoint bash neurascreen -c "curl -s http://host.docker.internal:3000 | head -5"
+```

--- a/docs/macro-recorder.md
+++ b/docs/macro-recorder.md
@@ -1,0 +1,84 @@
+# Macro Recorder
+
+Generate JSON scenarios by recording your browser interactions instead of writing them by hand.
+
+## Quick start
+
+```bash
+neurascreen record http://localhost:3000
+```
+
+A Chromium browser opens. Navigate, click, scroll as you normally would. When done, **close the browser window** (or press `Ctrl+C` in the terminal). The tool outputs a valid JSON scenario.
+
+## Options
+
+```bash
+neurascreen record <url> [OPTIONS]
+
+Options:
+  -o, --output PATH    Output JSON file path (default: output/<title>.json)
+  -t, --title TEXT     Scenario title (default: "Recorded Scenario")
+  -v, --verbose        Enable debug logging
+```
+
+## Examples
+
+```bash
+# Record with a custom title
+neurascreen record http://localhost:3000 -t "Onboarding flow"
+
+# Specify output path
+neurascreen record http://localhost:3000 -o scenarios/onboarding.json
+
+# Verbose mode for debugging
+neurascreen -v record http://localhost:3000
+```
+
+## What gets captured
+
+| Interaction | Scenario action | Notes |
+|-------------|----------------|-------|
+| Page navigation | `navigate` | URL path is extracted, duplicates are skipped |
+| Click on text | `click_text` | Used when the element has short visible text (< 50 chars) |
+| Click on icon/button | `click` | Fallback to CSS selector when no text is available |
+| Scroll | `scroll` | Debounced (500ms) to avoid duplicate entries |
+| Keyboard (Enter, Escape, Tab) | `key` | Only special keys are captured |
+| Pause > 2 seconds | `wait` | Capped at 10 seconds max |
+
+## How selectors are built
+
+The recorder tries to generate stable CSS selectors in this priority order:
+
+1. `#id` — Element ID (most stable)
+2. `[data-testid="..."]` — Test attribute
+3. `[name="..."]`, `[title="..."]`, `[aria-label="..."]` — Semantic attributes
+4. `tag.class1.class2` — Tag + classes (if unique on the page)
+5. `parent > tag:nth-child(n)` — Positional fallback
+
+## Workflow: record → edit → generate
+
+The recorder produces a **first draft**. You will typically want to:
+
+1. **Record** your interactions
+2. **Review** the JSON — remove unwanted clicks, fix selectors
+3. **Add narration** to `wait` steps
+4. **Adjust timing** — shorten or lengthen pauses
+5. **Validate**: `neurascreen validate my-scenario.json`
+6. **Preview**: `neurascreen preview my-scenario.json`
+7. **Generate**: `neurascreen full my-scenario.json`
+
+## Tips
+
+- **Close unrelated tabs** before recording to avoid noise
+- **Navigate slowly** — rapid clicking may generate duplicate events
+- **Use keyboard shortcuts** sparingly — only Enter, Escape and Tab are captured
+- **Check the output JSON** — the recorder captures raw events, some cleanup is usually needed
+- **Narration is empty** by default — add it manually after recording
+
+## Limitations
+
+- Only captures interactions on the main frame (not iframes)
+- Does not capture drag & drop (use `drag` action manually)
+- Does not capture form typing (use `type` action manually)
+- CSS selectors may be fragile for dynamically-generated elements
+- Scroll events are simplified to a fixed `direction: down, amount: 400`

--- a/docs/scenario-guide.md
+++ b/docs/scenario-guide.md
@@ -44,8 +44,8 @@ Follow the **action-then-narrate** pattern:
 ### 4. Validate and preview
 
 ```bash
-python -m src validate my-scenario.json
-python -m src preview my-scenario.json
+neurascreen validate my-scenario.json
+neurascreen preview my-scenario.json
 ```
 
 Fix any failing steps before recording.
@@ -53,7 +53,7 @@ Fix any failing steps before recording.
 ### 5. Generate the video
 
 ```bash
-python -m src full my-scenario.json
+neurascreen full my-scenario.json
 ```
 
 ## Tips

--- a/docs/subtitles-chapters.md
+++ b/docs/subtitles-chapters.md
@@ -1,0 +1,110 @@
+# Subtitles & YouTube Chapters
+
+Generate SRT subtitle files and YouTube chapter markers alongside your videos.
+
+## Subtitles (SRT)
+
+### Usage
+
+Add `--srt` to any `run`, `full` or `batch` command:
+
+```bash
+neurascreen full --srt scenario.json
+```
+
+This creates `output/scenario.srt` next to `output/scenario.mp4`.
+
+### Output format
+
+Standard SRT format, compatible with YouTube, VLC, and all major video players:
+
+```
+1
+00:00:04,206 --> 00:00:23,246
+Welcome to this demo of the dashboard module.
+
+2
+00:00:33,392 --> 00:01:04,272
+Here we can see the workflow editor with existing nodes.
+```
+
+### How it works
+
+- Each narrated step becomes one subtitle entry
+- Start time = real timestamp when the audio started playing during recording
+- End time = start time + audio duration (from the generated WAV file)
+- Text = the `narration` field from the scenario JSON
+
+### Using SRT files
+
+**YouTube**: Upload the `.srt` file in YouTube Studio > Subtitles > Add language > Upload file. Viewers can toggle subtitles on/off.
+
+**VLC**: Place the `.srt` file next to the `.mp4` with the same name. VLC loads it automatically.
+
+**Embed in video**: If you need hardcoded subtitles (burned into the video), use ffmpeg:
+
+```bash
+ffmpeg -i video.mp4 -vf subtitles=video.srt output.mp4
+```
+
+---
+
+## YouTube Chapters
+
+### Usage
+
+Add `--chapters` to any `run`, `full` or `batch` command:
+
+```bash
+neurascreen full --chapters scenario.json
+```
+
+This creates `output/scenario.chapters.txt`.
+
+### Output format
+
+YouTube-compatible chapter markers, one per line:
+
+```
+00:00 Introduction
+00:04 Dashboard overview
+00:33 Workflow editor
+01:12 Control flow palette
+01:36 Router node
+02:17 Guard node
+```
+
+### How it works
+
+- Each narrated step generates a chapter
+- The chapter title comes from the step's `title` field (falls back to "Section N" if empty)
+- Timestamps are taken from the real recording
+- An "Introduction" chapter at `00:00` is auto-inserted if the first narration starts later
+
+### Using chapter markers
+
+Copy the content of the `.chapters.txt` file into your YouTube video description. YouTube automatically detects the timestamp format and creates clickable chapters in the video player.
+
+**Requirements for YouTube chapters**:
+- First chapter must start at `00:00` (NeuraScreen handles this automatically)
+- Minimum 3 chapters
+- Each chapter must be at least 10 seconds long
+
+---
+
+## Combining both
+
+```bash
+# Single video with subtitles and chapters
+neurascreen full --srt --chapters scenario.json
+
+# Batch: all videos in a folder
+neurascreen batch scenarios/ --srt --chapters
+```
+
+## Tips
+
+- Write meaningful `title` fields in your scenario steps — they become chapter names
+- Keep narrations concise — long text makes subtitles hard to read
+- Use `--srt --chapters` together by default for production videos
+- The files are generated after the video, so they don't slow down recording

--- a/neurascreen/__init__.py
+++ b/neurascreen/__init__.py
@@ -1,3 +1,3 @@
 """NeuraScreen — Automated screen walkthrough video generator."""
 
-__version__ = "1.3.0"
+__version__ = "1.4.0"

--- a/neurascreen/cli.py
+++ b/neurascreen/cli.py
@@ -334,6 +334,34 @@ def batch(ctx: click.Context, folder_path: str, srt: bool, chapters: bool, narra
         sys.exit(1)
 
 
+@cli.command("record")
+@click.argument("url")
+@click.option("--output", "-o", type=click.Path(), help="Output JSON scenario path")
+@click.option("--title", "-t", default="Recorded Scenario", help="Scenario title")
+@click.pass_context
+def record(ctx: click.Context, url: str, output: str | None, title: str) -> None:
+    """Record browser interactions and generate a JSON scenario."""
+    config = Config.load()
+    logger = setup_logger("videogen", config.logs_dir, ctx.obj["verbose"])
+
+    from .macro import record_macro
+    from .utils import slugify
+
+    if output:
+        output_path = Path(output)
+    else:
+        output_path = config.output_dir / f"{slugify(title)}.json"
+
+    try:
+        result = record_macro(url, output_path, title=title)
+        click.echo(f"Scenario saved: {result}")
+    except KeyboardInterrupt:
+        click.echo("Recording stopped")
+    except Exception as e:
+        logger.error(f"Error: {e}")
+        sys.exit(1)
+
+
 @cli.command("list")
 def list_scenarios() -> None:
     """List available scenarios."""

--- a/neurascreen/macro.py
+++ b/neurascreen/macro.py
@@ -1,0 +1,271 @@
+"""Macro recorder: capture browser interactions and generate JSON scenarios."""
+
+import json
+import logging
+import time
+from pathlib import Path
+from urllib.parse import urlparse
+
+from playwright.sync_api import sync_playwright, Page, BrowserContext
+
+logger = logging.getLogger("videogen")
+
+# JavaScript injected into every page to capture user interactions
+_CAPTURE_SCRIPT = """
+(() => {
+    if (window.__neurascreen_recorder) return;
+    window.__neurascreen_recorder = true;
+    window.__neurascreen_events = window.__neurascreen_events || [];
+
+    document.addEventListener('click', (e) => {
+        const el = e.target;
+        const text = el.innerText?.trim().split('\\n')[0]?.substring(0, 80) || '';
+        const tag = el.tagName.toLowerCase();
+        const selector = _buildSelector(el);
+        window.__neurascreen_events.push({
+            type: 'click',
+            timestamp: Date.now(),
+            selector: selector,
+            text: text,
+            tag: tag,
+            url: window.location.pathname,
+        });
+    }, true);
+
+    document.addEventListener('scroll', (e) => {
+        // Debounce: only record scroll after 500ms of inactivity
+        clearTimeout(window.__neurascreen_scroll_timer);
+        window.__neurascreen_scroll_timer = setTimeout(() => {
+            window.__neurascreen_events.push({
+                type: 'scroll',
+                timestamp: Date.now(),
+                scrollY: window.scrollY,
+                url: window.location.pathname,
+            });
+        }, 500);
+    }, true);
+
+    document.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' || e.key === 'Escape' || e.key === 'Tab') {
+            window.__neurascreen_events.push({
+                type: 'key',
+                timestamp: Date.now(),
+                key: e.key,
+                url: window.location.pathname,
+            });
+        }
+    }, true);
+
+    function _buildSelector(el) {
+        // Try ID first
+        if (el.id) return '#' + el.id;
+
+        // Try unique attribute selectors
+        for (const attr of ['data-testid', 'name', 'title', 'aria-label']) {
+            const val = el.getAttribute(attr);
+            if (val) return el.tagName.toLowerCase() + '[' + attr + '="' + val + '"]';
+        }
+
+        // Try tag + class
+        if (el.className && typeof el.className === 'string') {
+            const classes = el.className.trim().split(/\\s+/).slice(0, 3).join('.');
+            if (classes) {
+                const sel = el.tagName.toLowerCase() + '.' + classes;
+                if (document.querySelectorAll(sel).length === 1) return sel;
+            }
+        }
+
+        // Fallback: tag + nth-child
+        const parent = el.parentElement;
+        if (parent) {
+            const siblings = Array.from(parent.children).filter(c => c.tagName === el.tagName);
+            if (siblings.length === 1) return _buildSelector(parent) + ' > ' + el.tagName.toLowerCase();
+            const index = siblings.indexOf(el) + 1;
+            return _buildSelector(parent) + ' > ' + el.tagName.toLowerCase() + ':nth-child(' + index + ')';
+        }
+
+        return el.tagName.toLowerCase();
+    }
+})();
+"""
+
+
+def record_macro(
+    url: str,
+    output_path: Path,
+    title: str = "Recorded Scenario",
+) -> Path:
+    """Open a browser, record user interactions, and save as JSON scenario.
+
+    The user interacts with the browser normally. When they close it
+    (or press Ctrl+C in the terminal), the recorded events are converted
+    to a NeuraScreen JSON scenario.
+
+    Args:
+        url: Starting URL to open.
+        output_path: Path for the output JSON file.
+        title: Title for the generated scenario.
+
+    Returns:
+        Path to the generated scenario file.
+    """
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    events = []
+    navigations = []
+
+    logger.info(f"Starting macro recorder at {url}")
+    logger.info("Interact with the browser. Close it or press Ctrl+C to stop recording.")
+
+    with sync_playwright() as pw:
+        browser = pw.chromium.launch(
+            headless=False,
+            args=["--disable-blink-features=AutomationControlled"],
+        )
+        context = browser.new_context(
+            locale="fr-FR",
+            timezone_id="Europe/Paris",
+            no_viewport=True,
+        )
+
+        page = context.new_page()
+
+        # Track navigations
+        def _on_navigation(frame):
+            if frame == page.main_frame:
+                navigations.append({
+                    "type": "navigate",
+                    "timestamp": int(time.time() * 1000),
+                    "url": urlparse(page.url).path,
+                })
+
+        page.on("framenavigated", _on_navigation)
+
+        # Inject capture script on every page load
+        page.add_init_script(_CAPTURE_SCRIPT)
+        page.goto(url, wait_until="domcontentloaded", timeout=15000)
+        page.wait_for_timeout(1000)
+
+        # Inject on current page too
+        page.evaluate(_CAPTURE_SCRIPT)
+
+        try:
+            # Wait until browser is closed by user
+            while True:
+                try:
+                    # Check if browser is still open
+                    page.evaluate("1")
+                    time.sleep(0.5)
+                except Exception:
+                    break
+        except KeyboardInterrupt:
+            logger.info("Recording stopped by user (Ctrl+C)")
+
+        # Collect events from the page
+        try:
+            captured = page.evaluate("window.__neurascreen_events || []")
+            events.extend(captured)
+        except Exception:
+            pass
+
+        try:
+            context.close()
+            browser.close()
+        except Exception:
+            pass
+
+    # Merge navigations and captured events, sorted by timestamp
+    all_events = navigations + events
+    all_events.sort(key=lambda e: e.get("timestamp", 0))
+
+    # Convert events to scenario steps
+    steps = _events_to_steps(all_events, url)
+
+    scenario = {
+        "title": title,
+        "description": f"Recorded from {url}",
+        "resolution": {"width": 1920, "height": 1080},
+        "steps": steps,
+    }
+
+    with open(output_path, "w", encoding="utf-8") as f:
+        json.dump(scenario, f, indent=2, ensure_ascii=False)
+
+    logger.info(f"Scenario saved: {output_path} ({len(steps)} steps)")
+    return output_path
+
+
+def _events_to_steps(events: list[dict], base_url: str) -> list[dict]:
+    """Convert raw browser events to NeuraScreen scenario steps."""
+    steps = []
+    last_url = urlparse(base_url).path
+    last_timestamp = 0
+
+    for event in events:
+        timestamp = event.get("timestamp", 0)
+        event_type = event.get("type", "")
+
+        # Add wait step if significant pause (>2s) between events
+        if last_timestamp > 0 and timestamp - last_timestamp > 2000:
+            gap_ms = min(timestamp - last_timestamp, 10000)
+            steps.append({
+                "action": "wait",
+                "duration": int(gap_ms),
+                "narration": "",
+            })
+
+        if event_type == "navigate":
+            url_path = event.get("url", "")
+            if url_path and url_path != last_url:
+                steps.append({
+                    "action": "navigate",
+                    "url": url_path,
+                    "wait": 1500,
+                })
+                last_url = url_path
+
+        elif event_type == "click":
+            text = event.get("text", "")
+            selector = event.get("selector", "")
+
+            # Prefer click_text for elements with meaningful text
+            if text and len(text) <= 50 and not text.isspace():
+                steps.append({
+                    "action": "click_text",
+                    "text": text,
+                    "wait": 1000,
+                })
+            elif selector:
+                steps.append({
+                    "action": "click",
+                    "selector": selector,
+                    "wait": 1000,
+                })
+
+        elif event_type == "scroll":
+            steps.append({
+                "action": "scroll",
+                "selector": "body",
+                "direction": "down",
+                "amount": 400,
+                "wait": 500,
+            })
+
+        elif event_type == "key":
+            key = event.get("key", "")
+            if key:
+                steps.append({
+                    "action": "key",
+                    "text": key,
+                    "wait": 500,
+                })
+
+        last_timestamp = timestamp
+
+    if not steps:
+        steps.append({
+            "action": "navigate",
+            "url": urlparse(base_url).path or "/",
+            "wait": 2000,
+        })
+
+    return steps

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "neurascreen"
-version = "1.3.0"
+version = "1.4.0"
 description = "Automated screen walkthrough video generator using Playwright, JSON scenarios and Text-to-Speech"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -1,0 +1,57 @@
+"""Tests for Docker configuration files."""
+
+from pathlib import Path
+
+import pytest
+
+
+PROJECT_ROOT = Path(__file__).parent.parent
+
+
+class TestDockerFiles:
+    """Verify Docker configuration files exist and are well-formed."""
+
+    def test_dockerfile_exists(self):
+        assert (PROJECT_ROOT / "Dockerfile").exists()
+
+    def test_dockerfile_has_from(self):
+        content = (PROJECT_ROOT / "Dockerfile").read_text()
+        assert content.startswith("FROM ")
+
+    def test_dockerfile_installs_ffmpeg(self):
+        content = (PROJECT_ROOT / "Dockerfile").read_text()
+        assert "ffmpeg" in content
+
+    def test_dockerfile_installs_xvfb(self):
+        content = (PROJECT_ROOT / "Dockerfile").read_text()
+        assert "xvfb" in content.lower() or "Xvfb" in content
+
+    def test_dockerfile_installs_playwright(self):
+        content = (PROJECT_ROOT / "Dockerfile").read_text()
+        assert "playwright install" in content
+
+    def test_dockerfile_sets_display(self):
+        content = (PROJECT_ROOT / "Dockerfile").read_text()
+        assert "DISPLAY" in content
+
+    def test_entrypoint_exists(self):
+        assert (PROJECT_ROOT / "docker-entrypoint.sh").exists()
+
+    def test_entrypoint_starts_xvfb(self):
+        content = (PROJECT_ROOT / "docker-entrypoint.sh").read_text()
+        assert "Xvfb" in content
+
+    def test_entrypoint_execs_neurascreen(self):
+        content = (PROJECT_ROOT / "docker-entrypoint.sh").read_text()
+        assert "exec neurascreen" in content
+
+    def test_dockerignore_exists(self):
+        assert (PROJECT_ROOT / ".dockerignore").exists()
+
+    def test_dockerignore_excludes_venv(self):
+        content = (PROJECT_ROOT / ".dockerignore").read_text()
+        assert ".venv" in content
+
+    def test_dockerignore_excludes_env(self):
+        content = (PROJECT_ROOT / ".dockerignore").read_text()
+        assert ".env" in content

--- a/tests/test_macro.py
+++ b/tests/test_macro.py
@@ -1,0 +1,129 @@
+"""Tests for macro recorder event-to-step conversion."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from neurascreen.macro import _events_to_steps
+
+
+class TestEventsToSteps:
+    """Tests for converting raw browser events to scenario steps."""
+
+    def test_empty_events_creates_navigate(self):
+        steps = _events_to_steps([], "http://localhost:3000/dashboard")
+        assert len(steps) == 1
+        assert steps[0]["action"] == "navigate"
+        assert steps[0]["url"] == "/dashboard"
+
+    def test_navigate_event(self):
+        events = [
+            {"type": "navigate", "timestamp": 1000, "url": "/settings"},
+        ]
+        steps = _events_to_steps(events, "http://localhost:3000/")
+        assert steps[0]["action"] == "navigate"
+        assert steps[0]["url"] == "/settings"
+
+    def test_duplicate_navigate_skipped(self):
+        events = [
+            {"type": "navigate", "timestamp": 1000, "url": "/page"},
+            {"type": "navigate", "timestamp": 1500, "url": "/page"},
+            {"type": "navigate", "timestamp": 2000, "url": "/other"},
+        ]
+        steps = _events_to_steps(events, "http://localhost:3000/page")
+        # Duplicate /page navigations are skipped, only /other remains
+        navigate_steps = [s for s in steps if s["action"] == "navigate"]
+        assert len(navigate_steps) == 1
+        assert navigate_steps[0]["url"] == "/other"
+
+    def test_click_with_text_uses_click_text(self):
+        events = [
+            {"type": "click", "timestamp": 1000, "text": "Save", "selector": "button.save", "tag": "button", "url": "/"},
+        ]
+        steps = _events_to_steps(events, "http://localhost:3000/")
+        assert steps[0]["action"] == "click_text"
+        assert steps[0]["text"] == "Save"
+
+    def test_click_without_text_uses_selector(self):
+        events = [
+            {"type": "click", "timestamp": 1000, "text": "", "selector": "#icon-btn", "tag": "button", "url": "/"},
+        ]
+        steps = _events_to_steps(events, "http://localhost:3000/")
+        assert steps[0]["action"] == "click"
+        assert steps[0]["selector"] == "#icon-btn"
+
+    def test_click_long_text_uses_selector(self):
+        events = [
+            {"type": "click", "timestamp": 1000, "text": "A" * 60, "selector": ".card", "tag": "div", "url": "/"},
+        ]
+        steps = _events_to_steps(events, "http://localhost:3000/")
+        assert steps[0]["action"] == "click"
+        assert steps[0]["selector"] == ".card"
+
+    def test_scroll_event(self):
+        events = [
+            {"type": "scroll", "timestamp": 1000, "scrollY": 400, "url": "/"},
+        ]
+        steps = _events_to_steps(events, "http://localhost:3000/")
+        assert steps[0]["action"] == "scroll"
+        assert steps[0]["direction"] == "down"
+
+    def test_key_event(self):
+        events = [
+            {"type": "key", "timestamp": 1000, "key": "Enter", "url": "/"},
+        ]
+        steps = _events_to_steps(events, "http://localhost:3000/")
+        assert steps[0]["action"] == "key"
+        assert steps[0]["text"] == "Enter"
+
+    def test_pause_creates_wait_step(self):
+        events = [
+            {"type": "click", "timestamp": 1000, "text": "A", "selector": ".a", "tag": "button", "url": "/"},
+            {"type": "click", "timestamp": 5000, "text": "B", "selector": ".b", "tag": "button", "url": "/"},
+        ]
+        steps = _events_to_steps(events, "http://localhost:3000/")
+        assert len(steps) == 3
+        assert steps[1]["action"] == "wait"
+        assert steps[1]["duration"] == 4000
+
+    def test_pause_capped_at_10s(self):
+        events = [
+            {"type": "click", "timestamp": 1000, "text": "A", "selector": ".a", "tag": "button", "url": "/"},
+            {"type": "click", "timestamp": 30000, "text": "B", "selector": ".b", "tag": "button", "url": "/"},
+        ]
+        steps = _events_to_steps(events, "http://localhost:3000/")
+        wait_step = [s for s in steps if s["action"] == "wait"][0]
+        assert wait_step["duration"] == 10000
+
+    def test_short_pause_no_wait_step(self):
+        events = [
+            {"type": "click", "timestamp": 1000, "text": "A", "selector": ".a", "tag": "button", "url": "/"},
+            {"type": "click", "timestamp": 2500, "text": "B", "selector": ".b", "tag": "button", "url": "/"},
+        ]
+        steps = _events_to_steps(events, "http://localhost:3000/")
+        assert all(s["action"] != "wait" for s in steps)
+
+    def test_mixed_events_order(self):
+        events = [
+            {"type": "navigate", "timestamp": 1000, "url": "/page1"},
+            {"type": "click", "timestamp": 2000, "text": "OK", "selector": ".ok", "tag": "button", "url": "/page1"},
+            {"type": "scroll", "timestamp": 2500, "scrollY": 300, "url": "/page1"},
+            {"type": "key", "timestamp": 3000, "key": "Escape", "url": "/page1"},
+        ]
+        steps = _events_to_steps(events, "http://localhost:3000/")
+        actions = [s["action"] for s in steps]
+        assert actions == ["navigate", "click_text", "scroll", "key"]
+
+    def test_base_url_path_extracted(self):
+        steps = _events_to_steps([], "http://localhost:3000/app/dashboard?tab=1")
+        assert steps[0]["url"] == "/app/dashboard"
+
+    def test_narration_always_empty(self):
+        events = [
+            {"type": "click", "timestamp": 1000, "text": "Go", "selector": ".go", "tag": "button", "url": "/"},
+        ]
+        steps = _events_to_steps(events, "http://localhost:3000/")
+        for step in steps:
+            if "narration" in step:
+                assert step["narration"] == ""


### PR DESCRIPTION
## Summary

- **Macro recorder** (`neurascreen record <url>`): opens a browser, captures clicks/navigations/scrolls/keys, outputs a valid JSON scenario
- **Docker container**: Dockerfile with Xvfb + PulseAudio for headless video generation on any server
- **Documentation**: 4 new guides + updated existing docs

## New files

| File | Description |
|------|-------------|
| `neurascreen/macro.py` | Macro recorder — JS event capture + event-to-step conversion |
| `Dockerfile` | Python 3.12 + ffmpeg + Xvfb + Playwright Chromium |
| `docker-entrypoint.sh` | Starts Xvfb + PulseAudio then runs neurascreen |
| `.dockerignore` | Excludes .venv, .env, tests, scenarios |
| `docs/macro-recorder.md` | Full guide: usage, captured events, workflow, limitations |
| `docs/subtitles-chapters.md` | SRT subtitles and YouTube chapters guide |
| `docs/docker.md` | Docker guide: build, volumes, CI/CD, troubleshooting |
| `docs/cross-platform.md` | macOS/Linux/Windows setup guide |
| `tests/test_macro.py` | 14 tests for event-to-step conversion |
| `tests/test_docker.py` | 12 tests for Docker file validation |

## Updated files

| File | Change |
|------|--------|
| `neurascreen/cli.py` | New `record` command |
| `README.md` | Sections for macro recorder, subtitles, batch, Docker + documentation table |
| `CONTRIBUTING.md` | Fix refs `src/` → `neurascreen/` |
| `docs/scenario-guide.md` | Fix refs `python -m src` → `neurascreen` |
| `ROADMAP.md` | Mark v1.4 complete |
| `.gitignore` | Add `output/*.json` |

## Closes

Closes #9 — Macro recorder: generate scenarios by recording browser interactions
Closes #13 — Docker container for headless generation

## Test plan

- [x] 160 unit tests passing (134 existing + 26 new)
- [x] Macro recorder tested: recorded 8 steps from localhost:8100
- [x] Docker build successful
- [x] Docker validate + preview headless: 7/7 steps passed